### PR TITLE
Add CORAL: Towards Autonomous Multi-Agent Evolution for Open-Ended Discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -783,6 +783,10 @@ Must-read Papers on Large Language Model Agents.
 
     *Yanjun Chen, Yirong Sun, Hanlin Wang, Xinming Zhang, Xiaoyu Shen, Wenjie Li, Wei Zhang.* [[abs](https://arxiv.org/abs/2603.06859)] [[code](https://github.com/EIT-EAST-Lab/C3)], 2026.3
 
+35. **CORAL: Towards Autonomous Multi-Agent Evolution for Open-Ended Discovery**
+
+    *Ao Qu, Han Zheng, Zijian Zhou, Yihao Yan, Yihong Tang, Shao Yong Ong, Fenglu Hong, Kaichen Zhou, Chonghe Jiang, Minwei Kong, Jiacheng Zhu, Xuan Jiang, Sirui Li, Cathy Wu, Bryan Kian Hsiang Low, Jinhua Zhao, Paul Pu Liang.* [[abs](https://arxiv.org/abs/2604.01658)] [[code](https://github.com/Human-Agent-Society/CORAL)], 2026.4
+
 
 ##### Adversarial Interactions 👨🏻‍🦳🗣
 


### PR DESCRIPTION
Hi — thanks for maintaining this awesome list!

I'd like to suggest adding our recent paper, **CORAL: Towards Autonomous Multi-Agent Evolution for Open-Ended Discovery**, which we think fits the scope of this list (self-evolving / autonomous multi-agent systems for open-ended discovery).

- **Paper:** https://arxiv.org/abs/2604.01658
- **Project page:** https://human-agent-society.github.io/CORAL/
- **Code:** https://github.com/Human-Agent-Society/CORAL

**TL;DR:** CORAL is the first framework for autonomous multi-agent evolution on open-ended problems. It replaces fixed heuristics and hard-coded exploration rules with long-running agents that explore, reflect, and collaborate through shared persistent memory, asynchronous multi-agent execution, and heartbeat-based interventions. It sets new SOTA on 10 math / algorithmic / systems-optimization tasks, with 3–10× higher improvement rates than fixed evolutionary-search baselines — and on Anthropic's kernel-engineering task, four co-evolving agents improve the best-known score from 1363 → 1103 cycles.

**BibTeX:**

```bibtex
@article{coral2026,
  title  = {CORAL: Towards Autonomous Multi-Agent Evolution for Open-Ended Discovery},
  author = {Qu, Ao and Zheng, Han and Zhou, Zijian and Yan, Yihao and Tang, Yihong and Ong, Shao Yong and Hong, Fenglu and Zhou, Kaichen and Jiang, Chonghe and Kong, Minwei and Zhu, Jiacheng and Jiang, Xuan and Li, Sirui and Wu, Cathy and Low, Bryan Kian Hsiang and Zhao, Jinhua and Liang, Paul Pu},
  journal = {arXiv preprint arXiv:2604.01658},
  year   = {2026},
  url    = {https://arxiv.org/abs/2604.01658}
}
```

Happy to reformat the entry or move it to a different section if you'd prefer — just let me know. Thanks for considering!
