### PR TITLE
Add survey: Harness Engineering for Language Agents (CAR) to Overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ Must-read Papers on Large Language Model Agents.
 9. **The Landscape of Agentic Reinforcement Learning for LLMs: A Survey**
 
    *Guibin Zhang, Hejia Geng, Xiaohang Yu, Zhenfei Yin, Zaibin Zhang, Zelin Tan, Heng Zhou, Zhongzhi Li, Xiangyuan Xue, Yijiang Li, Yifan Zhou, Yang Chen, Chen Zhang, Yutao Fan, Zihu Wang, Songtao Huang, Yue Liao, Hongru Wang, Mengyue Yang, Heng Ji, Michael Littman, Jun Wang, Shuicheng Yan, Philip Torr, Lei Bai.* [[abs](https://arxiv.org/abs/2509.02547)] [[code](https://github.com/xhyumiracle/Awesome-AgenticLLM-RL-Papers)], 2025.9
+
+10. **Harness Engineering for Language Agents: The Harness Layer as Control, Agency, and Runtime**
+
+   *Chaoyue He, Xin Zhou, Di Wang, Hong Xu, Wei Liu, Chunyan Miao.* [[abs](https://www.preprints.org/manuscript/202603.1756/v2)], 2026.3
    
 ---
 


### PR DESCRIPTION
Adds **"Harness Engineering for Language Agents: The Harness Layer as Control, Agency, and Runtime"** (He et al., 2026) to **Papers → Overview**, alongside the existing LLM-agent surveys.

It formalizes the agent **harness layer** as **Control, Agency, and Runtime (CAR)**, situates harness engineering in the arc from software → prompt → context engineering, audits 63 harness-relevant works, and proposes **HarnessCard** as a reporting artifact.

[[abs](https://www.preprints.org/manuscript/202603.1756/v2)] (DOI: 10.20944/preprints202603.1756)

Follows the Overview numbered format (title, then authors + [[abs]] + date).