### PR TITLE
Add PACT (enterprise AI assistant compliance benchmark) to Benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1032,6 +1032,11 @@ Must-read Papers on Large Language Model Agents.
 
     *Yuxuan Zhang, Yubo Wang, Yipeng Zhu, Penghui Du, Junwen Miao, Xuan Lu, Wendong Xu, Yunzhuo Hao, Songcheng Cai, Xiaochen Wang, Huaisong Zhang, Xian Wu, Yi Lu, Minyi Lei, Kai Zou, Huifeng Yin, Ping Nie, Liang Chen, Dongfu Jiang, Wenhu Chen, Kelsey R. Allen.* [[abs](https://arxiv.org/abs/2604.08523)] [[code](https://github.com/TIGER-AI-Lab/ClawBench)], 2026.4
 
+17. **PACT: Can Enterprise AI Assistants Be Trusted Under Pressure?**
+
+    *Mika Okamoto, Ansel Kaplan Erol.* [[abs](https://www.alphaxiv.org/pdf/2609.pact-enterprise-ai-compliance-testing)] [[code](https://github.com/trace-ai-labs/pact)] [[site](https://trace-ai-labs.github.io/pact/)], 2026.8
+
+
 ###  Types of Tools
 
 |      Types      | Tools                                                        |


### PR DESCRIPTION
Adds **PACT: Can Enterprise AI Assistants Be Trusted Under Pressure?** (preprint, 2026) as item 17 under Resources / Benchmarks.

PACT is a compliance benchmark of 3,364 multi-turn items across 12 regulated domains. It tests whether enterprise AI assistants keep following company rules when a deadline, a manager, or a pushy user makes breaking them convenient.

- Paper: https://www.alphaxiv.org/pdf/2609.pact-enterprise-ai-compliance-testing
- Site (leaderboard, results, trial transcripts): https://trace-ai-labs.github.io/pact/
- Dataset: https://huggingface.co/datasets/trace-ai-labs/pact
- Code: https://github.com/trace-ai-labs/pact