### PR TITLE
Add DRACO: Fine-Grained Credit Assignment with Dynamic Rubrics for Long-Horizon Agent Training

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,6 +632,10 @@ Must-read Papers on Large Language Model Agents.
 5. **In-the-Flow Agentic System Optimization for Effective Planning and Tool Use**
 
    *Zhuofeng Li, Haoxiang Zhang, Seungju Han, Sheng Liu, Jianwen Xie, Yu Zhang, Yejin Choi, James Zou, Pan Lu* [[abs](https://arxiv.org/abs/2510.05592)], 2025,10
+
+6. **DRACO: Fine-Grained Credit Assignment with Dynamic Rubrics for Long-Horizon Agent Training**
+
+   *Shubham Gandhi, Saurabh Goyal, Kiran Kate, Yara Rizk* [[abs](https://arxiv.org/abs/2609.04094)][[code](https://github.com/IBM/draco)], 2026.9
    
 ### 🤖💬🤖 Multiple Agents
 


### PR DESCRIPTION
This PR adds our recent paper to the **Agent > RL training** section, following the existing entry format.

**DRACO: Fine-Grained Credit Assignment with Dynamic Rubrics for Long-Horizon Agent Training**  
Shubham Gandhi, Saurabh Goyal, Kiran Kate, Yara Rizk (Carnegie Mellon University / IBM Research). arXiv 2609.04094, September 2026.
- Paper: https://arxiv.org/abs/2609.04094
- Code: https://github.com/IBM/draco

**Summary.** DRACO trains long-horizon tool-using agents with RL in the outcome-blind setting, where no verifier or ground-truth success signal is available. It generates task-specific rubrics dynamically during training, scores each finished trajectory once with an LLM judge, and redistributes the resulting GRPO advantage across steps in closed form using the judge's per-criterion attributions, with no learned attribution module. On AppWorld it gains 15.9 points over the base model and 5.3 points over GRPO trained on the ground-truth unit-test reward, and it transfers zero-shot to τ-Bench.

**Why here.** It is an RL training method for LLM agents, evaluated on AppWorld and τ-Bench, in the same vein as the GiGPO and SPA-RL entries already listed there.

I am an author of the paper. Happy to move the entry to a different section or adjust the format if you prefer.
